### PR TITLE
Require `"additionalProperties": false` in object

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2

--- a/src/converter.js
+++ b/src/converter.js
@@ -21,6 +21,9 @@ converter._merge_property = (merge_type, property_name, destination_value, sourc
   if(source_value === undefined){
     return destination_value
   }
+	if(typeof destination_value === 'boolean' && typeof source_value === 'boolean'){
+		return destination_value && source_value
+	}
   if(_.isPlainObject(destination_value) && _.isPlainObject(source_value)){
     return converter._merge_dicts(merge_type, destination_value, source_value)
   }
@@ -66,7 +69,7 @@ converter._merge_dicts_array = (merge_type, dest_dict, source_dicts) => { //Arra
     for(let j=0; j<keys.length;j++){
       const name = keys[j]
       const merged_property = converter._merge_property(merge_type, name, result[name], source_dict[name])
-      if(merged_property){
+			if(merged_property !== undefined){
         result[name] = merged_property
       }
     }
@@ -89,7 +92,7 @@ converter._merge_dicts = (merge_type, dest_dict, source_dict) => { //Merges a si
   for(let j=0; j<keys.length;j++){
     const name = keys[j]
     const merged_property = converter._merge_property(merge_type, name, result[name], source_dict[name])
-    if(merged_property){
+		if(merged_property !== undefined){
       result[name] = merged_property
     }
   }
@@ -121,6 +124,9 @@ converter._array = (name, node, mode) => {
 }
 
 converter._object = (name, node, mode) => {
+	if (node.additionalProperties !== false) {
+		throw new Error(`'object' type properties must have an '"additionalProperties": false' property:\n${JSON.stringify(node, null, 2)}`)
+	}
   const required_properties = node['required'] || []
   const properties = node['properties']
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -9,10 +9,6 @@ const JSON_SCHEMA_TO_BIGQUERY_TYPE_DICT = {
   string: 'STRING'
 }
 
-converter._isObject = (candidate) => {
-  return typeof candidate === 'object' && !Array.isArray(candidate)
-}
-
 converter._merge_property = (merge_type, property_name, destination_value, source_value) => {
   //Merges two properties.
   let destination_list
@@ -25,7 +21,7 @@ converter._merge_property = (merge_type, property_name, destination_value, sourc
   if(source_value === undefined){
     return destination_value
   }
-  if(converter._isObject(destination_value) && converter._isObject(source_value)){
+  if(_.isPlainObject(destination_value) && _.isPlainObject(source_value)){
     return converter._merge_dicts(merge_type, destination_value, source_value)
   }
   if(Array.isArray(destination_value)){

--- a/test/samples/allOf/input.json
+++ b/test/samples/allOf/input.json
@@ -11,7 +11,8 @@
 						"first_name": {
 							"type": "string"
 						}
-					}
+					},
+					"additionalProperties": false
 				},
 				{
 					"type": "object",
@@ -19,9 +20,11 @@
 						"last_name": {
 							"type": "string"
 						}
-					}
+					},
+					"additionalProperties": false
 				}
 			]
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/allOf_nested/input.json
+++ b/test/samples/allOf_nested/input.json
@@ -19,7 +19,8 @@
 								}
 							}
 						}
-					}
+					},
+					"additionalProperties": false
 				},
 				{
 					"type": "object",
@@ -33,11 +34,14 @@
 								"country": {
 									"type" : "string"
 								}
-							}
+							},
+							"additionalProperties": false
 						}
-					}
+					},
+					"additionalProperties": false
 				}
 			]
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/anyOfMultipleTypes/input.json
+++ b/test/samples/anyOfMultipleTypes/input.json
@@ -16,5 +16,6 @@
 	},
 	"required": [
 		"first_name"
-	]
-}	
+	],
+	"additionalProperties": false
+}

--- a/test/samples/complex/input.json
+++ b/test/samples/complex/input.json
@@ -12,7 +12,9 @@
 				"country": {
 					"type" : "string"
 				}
-			}
+			},
+			"additionalProperties": false
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/fieldDescription/input.json
+++ b/test/samples/fieldDescription/input.json
@@ -7,5 +7,6 @@
 			"description": "the first name",
 			"type": "string"
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/nestedDescription/input.json
+++ b/test/samples/nestedDescription/input.json
@@ -22,5 +22,6 @@
 				}
 			]
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/nestedRepeated/input.json
+++ b/test/samples/nestedRepeated/input.json
@@ -11,8 +11,10 @@
 					"first": {
 						"type": "string"
 					}
-				}
+				},
+				"additionalProperties": false
 			}
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/nullable/input.json
+++ b/test/samples/nullable/input.json
@@ -12,5 +12,6 @@
 	},
 	"required": [
 		"first_name"
-	]
+	],
+	"additionalProperties": false
 }

--- a/test/samples/oneof/input.json
+++ b/test/samples/oneof/input.json
@@ -55,7 +55,8 @@
                                             "number"
                                         ]
                                     }
-                                ]
+                                ],
+                                "additionalProperties": false
                             }
                         },
                         {
@@ -65,5 +66,6 @@
                 }
             }
         }
-    ]
+    ],
+		"additionalProperties": false
 }

--- a/test/samples/repeated/input.json
+++ b/test/samples/repeated/input.json
@@ -9,5 +9,6 @@
 				"type": "string"
 			}
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/simple/input.json
+++ b/test/samples/simple/input.json
@@ -9,5 +9,6 @@
 		"last_name": {
 			"type": "string"
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/timestamp/input.json
+++ b/test/samples/timestamp/input.json
@@ -7,5 +7,6 @@
 			"type": "string",
 			"format": "date-time"
 		}
-	}
+	},
+	"additionalProperties": false
 }

--- a/test/samples/typeArray/input.json
+++ b/test/samples/typeArray/input.json
@@ -18,5 +18,6 @@
 	},
 	"required": [
 		"first_name"
-	]
+	],
+	"additionalProperties": false
 }


### PR DESCRIPTION
This makes `"additionalProperties": false` required in all `object` type properties until Draft 8 comes and saves us with the saner way of checking for extraneous properties.