### PR TITLE
Support date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.2.0 (27/02/2020)
+
+* Now supports DATE columns.
+* Simplified custom error class.
+
 ## v3.1.1 (07/08/2019)
 
 * Logging now sent to STDERR.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonschema-bigquery",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Convert JSON schema to Google BigQuery schema",
   "main": "src/converter.js",
   "scripts": {

--- a/src/errors.js
+++ b/src/errors.js
@@ -10,16 +10,9 @@ class SchemaError extends Error {
     }
 
     this.name = 'SchemaError'
-    this._node = node
-  }
-
-  toString() {
-    let msg = super.toString()
-    if (!this._node) {
-      return msg
+    if (node) {
+      this.message += ':\n' + utils.inspector(node)
     }
-    msg += ':\n' + utils.inspector(this._node)
-    return msg
   }
 }
 

--- a/test/integration/samples/date/expected.json
+++ b/test/integration/samples/date/expected.json
@@ -1,0 +1,11 @@
+{
+	"schema": {
+		"fields": [
+			{
+				"name": "modified",
+				"type": "DATE",
+				"mode": "NULLABLE"
+			}
+		]
+	}
+}

--- a/test/integration/samples/date/input.json
+++ b/test/integration/samples/date/input.json
@@ -1,0 +1,12 @@
+{
+	"id": "http://yourdomain.com/schemas/myschema.json",
+	"description": "Example description",
+	"type": "object",
+	"properties": {
+		"modified": {
+			"type": "string",
+			"format": "date"
+		}
+	},
+	"additionalProperties": false
+}

--- a/test/unit/converter.js
+++ b/test/unit/converter.js
@@ -18,12 +18,15 @@ describe('converter', () => {
     })
   })
 
-  describe('_scalar()', () => {
+  describe('_bigQueryType()', () => {
     context('with an unknown type', () => {
       it('throws an error', () => {
         assert.throws(() => {
-          converter._scalar('a_name', undefined, 'NULLABLE', 'a description')
-        }, /Invalid type given: undefined for 'a_name'/)
+          const node = {
+            type: 'foo'
+          }
+          converter._bigQueryType(node, 'foo')
+        }, /SchemaError: Invalid type given: foo/)
       })
     })
   })


### PR DESCRIPTION
Add support for bigquery's `DATE` data type when a JSON schema string field uses a format of `date`.