### PR TITLE
Add ability to continue schema generation if errors in json are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note that some features involve bespoke interpretation of schema details suited 
 
 ## Consume
 
-    jsbq -p <gbq project> -d <gbq dataset> -j <json schema file> --preventAdditionalObjectProperties
+    jsbq -p <gbq project> -d <gbq dataset> -j <json schema file> --preventAdditionalObjectProperties --continueOnError
 
 For embedded usage the following will allow and support runtime schema conversion and table maintenance:
 
@@ -33,11 +33,13 @@ Please ensure that the input JSON schema is dereferenced so that all external re
 
 ```
 {
-  preventAdditionalObjectProperties: true
+  preventAdditionalObjectProperties: true,
+  continueOnError: true
 }
 ```
 
 * `preventAdditionalObjectProperties` - boolean, check for additional object properties in schemas.
+* `continueOnError` - boolean, continues conversion if problem json is encountered.  Problems will be excluded from resulting schema.
 
 ## Test
 

--- a/bin/jsbq
+++ b/bin/jsbq
@@ -47,7 +47,7 @@ jsbq.run = async () => {
   const readFile = promisify(fs.readFile)
 
   const argv = require('yargs')
-  .usage('Usage: $0 -p [project] -d [dataset] -j <json schema file> --preventAdditionalObjectProperties')
+  .usage('Usage: $0 -p [project] -d [dataset] -j <json schema file> --preventAdditionalObjectProperties --continueOnError')
   .options({
     j: {
       describe: 'JSON schema file',
@@ -64,6 +64,11 @@ jsbq.run = async () => {
       type: 'boolean',
       default: false
     },
+    continueOnError: {
+      describe: 'boolean, if error in json schema, skip element in big query schema and continue.',
+      type: 'boolean',
+      default:false
+    },
     debug: {
       describe: 'Enable debug logging',
       type: 'boolean',
@@ -79,7 +84,8 @@ jsbq.run = async () => {
 
   const schemaData = await readFile(argv.j)
   const options = {
-    preventAdditionalObjectProperties: argv.preventAdditionalObjectProperties
+    preventAdditionalObjectProperties: argv.preventAdditionalObjectProperties,
+    continueOnError: argv.continueOnError
   }
   const jsonSchema = JSON.parse(schemaData)
   logger.debug('Input schema: ', jsonSchema)

--- a/src/converter.js
+++ b/src/converter.js
@@ -135,33 +135,49 @@ converter._array = (name, node) => {
 }
 
 converter._object = (name, node, mode) => {
-  if (node.additionalProperties !== false && converter._options.preventAdditionalObjectProperties) {
-    throw new SchemaError('"object" type properties must have an \'"additionalProperties": false\' property', node)
-  }
-  if(!_.isPlainObject(node.properties)){
-    throw new SchemaError('No properties defined for object', node)
-  }
-  if(Object.keys(node.properties).length === 0){
-    throw new SchemaError('Record fields must have one or more child fields', node)
-  }
-  const required_properties = node.required || []
-  const properties = node.properties
 
-  const fields = Object.keys(properties).map( key => {
-    const required = required_properties.includes(key) ? 'REQUIRED' : 'NULLABLE'
-    return converter._visit(key,properties[key], required)
-  })
+  let result
 
-  const result = {
-    name: name,
-    type: 'RECORD',
-    mode: mode,
-    fields: fields
+  try {
+    if (node.additionalProperties !== false && converter._options.preventAdditionalObjectProperties) {
+      throw new SchemaError('"object" type properties must have an \'"additionalProperties": false\' property', node)
+    }
+    if(!_.isPlainObject(node.properties)){
+      throw new SchemaError('No properties defined for object', node)
+    }
+    if(Object.keys(node.properties).length === 0){
+      throw new SchemaError('Record fields must have one or more child fields', node)
+    }
+    const required_properties = node.required || []
+    const properties = node.properties
+
+    let fields = Object.keys(properties).map( key => {
+      const required = required_properties.includes(key) ? 'REQUIRED' : 'NULLABLE'
+      return converter._visit(key,properties[key], required)
+    })
+
+    //remove empty fields
+    fields = fields.filter(function (field) {
+      return field != null
+    })
+
+    result = {
+      name: name,
+      type: 'RECORD',
+      mode: mode,
+      fields: fields
+    }
+
+    if(node.description){
+      result.description = node.description
+    }
+  }
+  catch (e) {
+    if(!converter._options.continueOnError) {
+      throw(e)
+    } 
   }
 
-  if(node.description){
-    result.description = node.description
-  }
   return result
 }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -222,7 +222,8 @@ converter._visit = (name, node, mode='NULLABLE') => {
     if(non_null_types.length > 1){
       throw new SchemaError('Union type not supported', node)
     }
-    if(type_.includes('null')){
+    //When mode is REPEATED, we want to leave it, even if it is NULLABLE
+    if(type_.includes('null') && actual_mode !== 'REPEATED' ){
       actual_mode = 'NULLABLE'
     }
     type_ = non_null_types[0]

--- a/test/integration/continueOnError/emptyObject/expected.json
+++ b/test/integration/continueOnError/emptyObject/expected.json
@@ -1,0 +1,18 @@
+{
+	"schema": {
+		"fields": [
+			{
+				"name": "address",
+				"type": "RECORD",
+				"mode": "NULLABLE",
+				"fields":[
+					{
+						"name": "street_address",
+						"type": "STRING",
+						"mode": "NULLABLE"
+					}
+				]
+			}
+		]
+	}
+}

--- a/test/integration/continueOnError/emptyObject/input.json
+++ b/test/integration/continueOnError/emptyObject/input.json
@@ -1,0 +1,20 @@
+{
+	"id": "http://yourdomain.com/schemas/myschema.json",
+	"description": "Complex example empty Object",
+	"type": "object",
+	"properties": {
+		"address": {
+			"type": "object",
+			"properties": {
+				"street_address": {
+					"type": "string"
+				},
+				"country": {
+					"type" : "object"
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": false
+}

--- a/test/integration/converter.js
+++ b/test/integration/converter.js
@@ -6,6 +6,8 @@ describe('converter', () => {
   describe('run()', () => {
     const sampleDir = './test/integration/samples'
     const testDirs = fs.readdirSync(sampleDir)
+    const continueOnErrorTestDir = './test/integration/continueOnError'
+    const continueOnErrorTestDirs = fs.readdirSync(continueOnErrorTestDir)
 
     testDirs.forEach(dir => {
       describe(dir, () => {
@@ -15,6 +17,27 @@ describe('converter', () => {
 
         before(() => {
           result = converter.run(inJson,'p','t')
+        })
+
+        it('converts to big query', () => {
+          assert.deepStrictEqual(result, expected)
+        })
+      })
+    })
+
+    continueOnErrorTestDirs.forEach(dir => {
+      describe(dir, () => {
+        const inJson = require(`../../${continueOnErrorTestDir}/${dir}/input.json`)
+        const expected = require(`../../${continueOnErrorTestDir}/${dir}/expected.json`)
+        const options = {
+          continueOnError: true
+        }
+
+        let result
+
+        before(() => {
+          
+          result = converter.run(inJson, options, 'p','t')
         })
 
         it('converts to big query', () => {

--- a/test/unit/converter.js
+++ b/test/unit/converter.js
@@ -159,6 +159,38 @@ describe('converter', () => {
         }, /Record fields must have one or more child fields/)
       })
     })
+
+    context('with no properties continueOnError', () => {
+      beforeEach(() => {
+        converter._options = {
+          continueOnError: true
+        }
+      })
+
+      it('does not allow objects to not have properties defined', () => {
+        
+        assert.doesNotThrow(() => {
+          converter._object('test', {}, 'NULLABLE')
+        }, /No properties defined for object/)
+      })
+    })
+
+    context('with zero properties continueOnError', () => {
+      beforeEach(() => {
+        converter._options = {
+          continueOnError: true
+        }
+      })
+
+      it('does not allow objects to have zero properties defined', () => {
+        const node = {
+          properties: {}
+        }
+        assert.doesNotThrow(() => {
+          converter._object('test', node, 'NULLABLE')
+        }, /Record fields must have one or more child fields/)
+      })
+    })
   })
 
   describe('run()', () => {


### PR DESCRIPTION
I have an extremely deep and complex json schema document.  In some cases there are elements in the schema that aren't acceptable by BigQuery.  One such issue is an object with no defined properties.  This is acceptable in the application that uses the schema, but we want to ignore these issues in the Big Query Schema that is generated.
The changes in this PR meet my needs, but may need to be generalized.

Thanks, Adam Widi  