### PR TITLE
Changed number type from float to numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.0 (21/12/2021)
+
+* Updated converter to generate numeric instead of float for number type
+
 ## v4.1.0 (27/09/2021)
 
 * Now checks for field name format.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonschema-bigquery",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Convert JSON schema to Google BigQuery schema",
   "main": "src/converter.js",
   "scripts": {

--- a/src/converter.js
+++ b/src/converter.js
@@ -7,7 +7,7 @@ const JSON_SCHEMA_TO_BIGQUERY_TYPE_DICT = {
   boolean: 'BOOLEAN',
   'date-time': 'TIMESTAMP',
   integer: 'INTEGER',
-  number: 'FLOAT',
+  number: 'NUMERIC',
   string: 'STRING',
   date: 'DATE'
 }

--- a/test/integration/samples/numeric/expected.json
+++ b/test/integration/samples/numeric/expected.json
@@ -1,0 +1,11 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "modified",
+                "type": "NUMERIC",
+                "mode": "NULLABLE"
+            }
+        ]
+    }
+}

--- a/test/integration/samples/numeric/input.json
+++ b/test/integration/samples/numeric/input.json
@@ -1,0 +1,11 @@
+{
+    "id": "http://yourdomain.com/schemas/myschema.json",
+    "description": "Example description",
+    "type": "object",
+    "properties": {
+        "modified": {
+            "type": "number"
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
Currently, when number is passed into a schema this is being converted to a float on BigQuery. 

This is not ideal as floats aren't stored exactly as they appear and will output results to 15+ decimal places. As such the change here is to convert to numeric instead, which will be much more accurate for monetary values.