### PR TITLE
Support draft-7 or newer schemas with jsbq CLI tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.0.1 (04/07/2022)
+
+* JSBQ CLI now supports draft-7+ schemas
+* Updated dependencies
+
 ## v5.0.0 (30/12/2021)
 
 * Updated converter to generate numeric instead of float for number type.

--- a/bin/jsbq
+++ b/bin/jsbq
@@ -19,8 +19,9 @@ jsbq.process = async (project, datasetName, jsonSchema, options) => {
     return logger.info('Skipping table operations')
   }
 
-  logger.info('Extracting table name from schema...')
-  const tableName = utils.get_table_id(jsonSchema.id)
+  const schemaId = jsonSchema.$id || jsonSchema.id
+  logger.info('Extracting table name from schema ID:', schemaId)
+  const tableName = utils.get_table_id(schemaId)
   logger.info('Table name:', tableName)
 
   logger.info('Setting table options...')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonschema-bigquery",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Convert JSON schema to Google BigQuery schema",
   "main": "src/converter.js",
   "scripts": {


### PR DESCRIPTION
Now checking for `$id` as well as `id` ID property when generating the table name.