### PR TITLE
Output raw JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ Please ensure that the input JSON schema is dereferenced so that all external re
 - `preventAdditionalObjectProperties` - boolean, check for additional object properties in schemas.
 - `continueOnError` - boolean, continues conversion if problem JSON is encountered. Problems will be excluded from resulting schema.
 
+### Usage with bq CLI tool
+
+Google maintains a CLI tool called `bq` which allows the management of BigQuery tables:
+
+https://cloud.google.com/bigquery/docs/reference/bq-cli-reference
+
+To create a table from a JSON schema using other options that our `jsbq` does not support, use the following commands:
+
+First, output the generated GBQ schema to a file:
+
+```
+npx jsbq -j test/integration/samples/complex/input.json > /tmp/schema.json
+```
+
+Then run the `bq` command to create a table:
+
+```
+bq mk --schema=/tmp/schema.json test_dataset.test_table
+```
+
+Please see the bq reference for table creation options:
+
+https://cloud.google.com/bigquery/docs/reference/bq-cli-reference#bq_mk
+
 ## Test
 
     npm test

--- a/bin/jsbq
+++ b/bin/jsbq
@@ -3,7 +3,7 @@
 const jsbq = module.exports = {}
 
 const gbq = require('../src/gbq')
-const utils = require('../src/utils')
+const { get_table_id } = require('../src/utils')
 const converter = require('../src/converter')
 const { logger } = require('../src/log')
 const fs = require('fs')
@@ -13,7 +13,7 @@ jsbq.process = async (project, datasetName, jsonSchema, options) => {
   logger.info('Processing JSON schema...')
   const tableOptions = converter.run(jsonSchema, options)
   logger.info('Generated BigQuery schema:')
-  console.log(JSON.stringify(tableOptions))
+  console.log(JSON.stringify(tableOptions.schema.fields))
 
   if (!project && !datasetName) {
     return logger.info('Skipping table operations')
@@ -21,7 +21,7 @@ jsbq.process = async (project, datasetName, jsonSchema, options) => {
 
   const schemaId = jsonSchema.$id || jsonSchema.id
   logger.info('Extracting table name from schema ID:', schemaId)
-  const tableName = utils.get_table_id(schemaId)
+  const tableName = get_table_id(schemaId)
   logger.info('Table name:', tableName)
 
   logger.info('Setting table options...')

--- a/bin/jsbq
+++ b/bin/jsbq
@@ -13,7 +13,7 @@ jsbq.process = async (project, datasetName, jsonSchema, options) => {
   logger.info('Processing JSON schema...')
   const tableOptions = converter.run(jsonSchema, options)
   logger.info('Generated BigQuery schema:')
-  console.log(utils.inspector(tableOptions))
+  console.log(JSON.stringify(tableOptions))
 
   if (!project && !datasetName) {
     return logger.info('Skipping table operations')

--- a/tablediff/create_tables.sh
+++ b/tablediff/create_tables.sh
@@ -5,9 +5,9 @@
 
 for EVENT_VERSION in `cat events.list`
 do
-echo Starting $schema
-cp $SCHEMA_PATH/$EVENT_VERSION/schema.json ../src
-node ../src/jsbq.js -p $PROJECT -d $DATASET -j schema.json
+  echo Starting $schema
+  cp $SCHEMA_PATH/$EVENT_VERSION/schema.json ../src
+  bin/jsbq -p $PROJECT -d $DATASET -j schema.json
 done
 
 echo Finished


### PR DESCRIPTION
The JSBQ CLI tool will now output the raw JSON required for the BQ CLI tool:

```
% bin/jsbq -j test/integration/samples/simple/input.json 
2022-08-08T20:39:17.845 INFO default Processing JSON schema...
2022-08-08T20:39:17.864 INFO default Generated BigQuery schema:
{"schema":{"fields":[{"name":"first_name","type":"STRING","mode":"NULLABLE"},{"name":"last_name","type":"STRING","mode":"NULLABLE"}]}}
2022-08-08T20:39:17.870 INFO default Skipping table operations
```

Have updated docs on how to use this output.