### PR TITLE
Add conversion to BigQuery `JSON` type

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -183,9 +183,8 @@ converter._object = (name, node, mode) => {
       // Big Query can handle semi-structured data :
       // https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#loading_semi-structured_json_data
       fieldType = 'JSON'
-    }
-
-    if (hasProperties && Object.keys(node.properties).length === 0) {
+      return converter._scalar(name, fieldType, mode, node.description)
+    } else if (Object.keys(node.properties).length === 0) {
       throw new SchemaError(
         'Record fields must have one or more child fields',
         node
@@ -194,23 +193,21 @@ converter._object = (name, node, mode) => {
 
     result = converter._scalar(name, fieldType, mode, node.description)
 
-    if (hasProperties) {
-      const required_properties = node.required || []
-      const properties = node.properties
+    const required_properties = node.required || []
+    const properties = node.properties
 
-      let fields = Object.keys(properties).map((key) => {
-        const required = required_properties.includes(key)
-          ? 'REQUIRED'
-          : 'NULLABLE'
-        return converter._visit(key, properties[key], required)
-      })
+    let fields = Object.keys(properties).map((key) => {
+      const required = required_properties.includes(key)
+        ? 'REQUIRED'
+        : 'NULLABLE'
+      return converter._visit(key, properties[key], required)
+    })
 
-      // remove empty fields
-      fields = fields.filter(function (field) {
-        return field != null
-      })
-      result.fields = fields
-    }
+    // remove empty fields
+    fields = fields.filter(function (field) {
+      return field != null
+    })
+    result.fields = fields
   } catch (e) {
     if (!converter._options.continueOnError) {
       throw e

--- a/test/integration/continueOnError/emptyObject/input.json
+++ b/test/integration/continueOnError/emptyObject/input.json
@@ -10,7 +10,8 @@
           "type": "string"
         },
         "country": {
-          "type": "object"
+          "type": "object",
+          "properties": {}
         }
       },
       "additionalProperties": false

--- a/test/integration/samples/json/expected.json
+++ b/test/integration/samples/json/expected.json
@@ -1,0 +1,12 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "description": "Some json data without specific schema.",
+        "name": "semi_structured",
+        "type": "JSON",
+        "mode": "NULLABLE"
+      }
+    ]
+  }
+}

--- a/test/integration/samples/json/input.json
+++ b/test/integration/samples/json/input.json
@@ -1,0 +1,12 @@
+{
+  "id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Example description",
+  "type": "object",
+  "properties": {
+    "semi_structured": {
+      "description": "Some json data without specific schema.",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/unit/converter.js
+++ b/test/unit/converter.js
@@ -118,10 +118,15 @@ describe('converter unit', () => {
     })
 
     context('with no properties', () => {
-      it('does not allow objects to not have properties defined', () => {
-        assert.throws(() => {
-          converter._object('test', {}, 'NULLABLE')
-        }, /No properties defined for object/)
+      it('converts to JSON when properties not defined', () => {
+        const expected = {
+          mode: 'NULLABLE',
+          name: 'test',
+          type: 'JSON',
+        }
+        const result = converter._object('test', {}, 'NULLABLE')
+
+        assert.deepStrictEqual(result, expected)
       })
     })
 


### PR DESCRIPTION
This PR adds conversion of fields with type `object` and no child properties to BiQuery `JSON` type.

See https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#loading_semi-structured_json_data
