### PR TITLE
Unevaluated properties now considered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.0 (27/01/2023)
+
+- unevaluatedProperties now supported when checking for additional properties.
+
 ## v6.0.0 (24/01/2023)
 
 - Objects with no properties convert to JSON fields.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonschema-bigquery",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Convert JSON schema to Google BigQuery schema",
   "main": "src/converter.js",
   "scripts": {

--- a/test/integration/converter.js
+++ b/test/integration/converter.js
@@ -54,6 +54,33 @@ describe('converter integration', () => {
     })
   })
 
+  describe('preventAdditionalObjectProperties option', () => {
+    const sampleDir = './test/integration/preventAdditionalObjectProperties'
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    const testDirs = fs.readdirSync(sampleDir)
+
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    testDirs.forEach((dir) => {
+      describe(dir, () => {
+        let expected
+        let result
+
+        before(() => {
+          const inJson = require(`../../${sampleDir}/${dir}/input.json`)
+          expected = require(`../../${sampleDir}/${dir}/expected.json`)
+          const options = {
+            preventAdditionalObjectProperties: true,
+          }
+          result = converter.run(inJson, options, 'p', 't')
+        })
+
+        it('converts to big query', () => {
+          assert.deepStrictEqual(result, expected)
+        })
+      })
+    })
+  })
+
   describe('continueOnError and preventAdditionalObjectProperties options', () => {
     const sampleDir =
       './test/integration/continueOnErrorAndPreventAdditionalObjectProperties'

--- a/test/integration/preventAdditionalObjectProperties/additionalPropertiesFalse/expected.json
+++ b/test/integration/preventAdditionalObjectProperties/additionalPropertiesFalse/expected.json
@@ -1,0 +1,16 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "first_name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "last_name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      }
+    ]
+  }
+}

--- a/test/integration/preventAdditionalObjectProperties/additionalPropertiesFalse/input.json
+++ b/test/integration/preventAdditionalObjectProperties/additionalPropertiesFalse/input.json
@@ -1,0 +1,14 @@
+{
+  "id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Example description",
+  "type": "object",
+  "properties": {
+    "first_name": {
+      "type": "string"
+    },
+    "last_name": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/integration/preventAdditionalObjectProperties/unevaluatedPropertiesFalse/expected.json
+++ b/test/integration/preventAdditionalObjectProperties/unevaluatedPropertiesFalse/expected.json
@@ -1,0 +1,16 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "first_name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "last_name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      }
+    ]
+  }
+}

--- a/test/integration/preventAdditionalObjectProperties/unevaluatedPropertiesFalse/input.json
+++ b/test/integration/preventAdditionalObjectProperties/unevaluatedPropertiesFalse/input.json
@@ -1,0 +1,14 @@
+{
+  "id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Example description",
+  "type": "object",
+  "properties": {
+    "first_name": {
+      "type": "string"
+    },
+    "last_name": {
+      "type": "string"
+    }
+  },
+  "unevaluatedProperties": false
+}

--- a/test/unit/converter.js
+++ b/test/unit/converter.js
@@ -96,11 +96,11 @@ describe('converter unit', () => {
         }
         assert.doesNotThrow(() => {
           converter._object('test', node, 'NULLABLE')
-        }, /"object" type properties must have an '"additionalProperties": false' property/)
+        }, /Objects must not have additional or unevaluated properties/)
       })
     })
 
-    context('with the "ignoreAdditional" option', () => {
+    context('with the "preventAdditionalObjectProperties" option', () => {
       beforeEach(() => {
         converter._options = {
           preventAdditionalObjectProperties: true,
@@ -113,7 +113,7 @@ describe('converter unit', () => {
         }
         assert.throws(() => {
           converter._object('test', node, 'NULLABLE')
-        }, /"object" type properties must have an '"additionalProperties": false' property/)
+        }, /Objects must not have additional or unevaluated properties/)
       })
     })
 


### PR DESCRIPTION
When checking for additional properties, now consider the `"unevaluatedProperties": false` JSON schema setting as well as the previous `"additionalProperties: false"` setting.